### PR TITLE
Update graphqler.py

### DIFF
--- a/graphqler.py
+++ b/graphqler.py
@@ -580,7 +580,8 @@ def main():
     QueryRunner.url = args.url
 
     if args.file is not None:
-        schema = open(args.file).read()
+        with open(args.file) as f:
+            schema = json.loads(f.read())
         
     if args.cookie is not None:
         cookie_dir = {}


### PR DESCRIPTION
Fixed a bug which did NOT parse JSON when load response.json (the result of introspection query)


(venv) labs :: graphql/graphqler » python graphqler.py -f ~/Desktop/response.json -u "http://3.x.x.132:4000/graphql"  -m all_args Traceback (most recent call last):
  File "/Users/x/graphql/graphqler/graphqler.py", line 666, in <module>
    main()
  File "/Users/x/graphql/graphqler/graphqler.py", line 617, in main
    query_type_name,mutation_type_name = get_query_and_mutation_types(schema)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/x/graphql/graphqler/graphqler.py", line 305, in get_query_and_mutation_types
    if schema['data']['__schema']['queryType'] is not None:
       ~~~~~~^^^^^^^^
TypeError: string indices must be integers, not 'str'